### PR TITLE
Fix semantic versioning handling and version lookup

### DIFF
--- a/loader/src/main/java/de/rhm176/silk/loader/EquilinoxGameProvider.java
+++ b/loader/src/main/java/de/rhm176/silk/loader/EquilinoxGameProvider.java
@@ -57,12 +57,12 @@ public class EquilinoxGameProvider implements GameProvider {
 
     @Override
     public String getRawGameVersion() {
-        return version.name();
+        return version.rawName();
     }
 
     @Override
     public String getNormalizedGameVersion() {
-        return version.name();
+        return version.displayName();
     }
 
     @Override

--- a/loader/src/main/java/de/rhm176/silk/loader/EquilinoxVersion.java
+++ b/loader/src/main/java/de/rhm176/silk/loader/EquilinoxVersion.java
@@ -21,12 +21,13 @@ package de.rhm176.silk.loader;
  * This record holds the display name of the version (e.g., "1.7.4") and
  * an optional Java class file version number (e.g., 52 for Java 8).
  *
- * @param name The display name of the game version (e.g., "1.7.4"). This should not be null.
+ * @param rawName The raw name of the game version (e.g., "1.7.0b"). This should not be null.
+ * @param displayName The display name of the game version (e.g., "1.7.0-beta"). This should not be null.
  * @param classVersion The Java class file major version number associated with this game version, if known.
  * This can be null if the class version is not determined or not applicable.
  * Common values: 52 (Java 8).
  */
-public record EquilinoxVersion(String name, Integer classVersion) {
+public record EquilinoxVersion(String rawName, String displayName, Integer classVersion) {
     /**
      * Canonical constructor for the EquilinoxVersion record.
      *
@@ -36,13 +37,23 @@ public record EquilinoxVersion(String name, Integer classVersion) {
     public EquilinoxVersion {}
 
     /**
+     * Gets the raw name of the game version.
+     * 
+     * @return The non-null raw name of the version.
+     */
+    @Override
+    public String rawName() {
+        return rawName;
+    }
+
+    /**
      * Gets the display name of the game version.
      *
      * @return The non-null display name of the version.
      */
     @Override
-    public String name() {
-        return name;
+    public String displayName() {
+        return displayName;
     }
 
     /**


### PR DESCRIPTION
This PR fixes crashes when launching versions like `1.7.0b` by using `1.7.0-beta` as normalized name and `1.7.0b` as raw name. Additionally, it handles:
- `<major>.<minor>.<patch>a` by converting it to `<major>.<minor>.<patch>-alpha`
- `<major>.<minor>.<patch>rc<number>` by converting it to `<major>.<minor>.<patch>-rc.<number>`.

I don't know if these two are actually used by the game, but adding them shouldn't hurt.